### PR TITLE
Add logout endpoint and revoke refresh tokens

### DIFF
--- a/src/main/java/com/nosde/memo/application/dto/LogoutRequest.java
+++ b/src/main/java/com/nosde/memo/application/dto/LogoutRequest.java
@@ -1,0 +1,6 @@
+package com.nosde.memo.application.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record LogoutRequest(@NotBlank(message = "Refresh token é obrigatório") String refreshToken) {
+}

--- a/src/main/java/com/nosde/memo/application/service/AuthService.java
+++ b/src/main/java/com/nosde/memo/application/service/AuthService.java
@@ -98,6 +98,25 @@ public class AuthService {
         }
     }
 
+    public void logout(User user, String refreshToken) {
+        if (user == null) {
+            throw new IllegalArgumentException("Usuário inválido");
+        }
+
+        if (UtHelper.isNullOrEmpty(refreshToken)) {
+            throw new IllegalArgumentException("Refresh token não pode ser vazio");
+        }
+
+        RefreshToken token = refreshTokenRepository.findByToken(refreshToken)
+            .orElseThrow(() -> new BadCredentialsException("Refresh token inválido"));
+
+        if (token.getUser() == null || !token.getUser().getId().equals(user.getId())) {
+            throw new BadCredentialsException("Refresh token não pertence ao usuário autenticado");
+        }
+
+        refreshTokenRepository.delete(token);
+    }
+
     public TokenResponse refresh(String refreshToken) {
         Optional<RefreshToken> token = refreshTokenRepository.findByToken(refreshToken);
         if (!token.isPresent() || token.get().getExpiryDate().isBefore(java.time.Instant.now())) {

--- a/src/main/java/com/nosde/memo/interfaces/controller/AuthController.java
+++ b/src/main/java/com/nosde/memo/interfaces/controller/AuthController.java
@@ -2,6 +2,7 @@ package com.nosde.memo.interfaces.controller;
 
 import java.util.Map;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -10,6 +11,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.nosde.memo.application.dto.AuthResponse;
+import com.nosde.memo.application.dto.LogoutRequest;
 import com.nosde.memo.application.dto.LoginRequest;
 import com.nosde.memo.application.dto.RegisterRequest;
 import com.nosde.memo.application.dto.UserDto;
@@ -17,10 +19,13 @@ import com.nosde.memo.application.service.AuthService;
 import com.nosde.memo.application.service.JwtService;
 import com.nosde.memo.application.service.RefreshTokenService;
 import com.nosde.memo.domain.model.RefreshToken;
+import com.nosde.memo.domain.model.User;
 import com.nosde.memo.domain.repository.RefreshTokenRepository;
 import com.nosde.memo.domain.repository.UserRepository;
 
 import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
@@ -45,6 +50,17 @@ public class AuthController {
     @PostMapping("/login")
     public ResponseEntity<AuthResponse> login(@RequestBody @Valid LoginRequest request) {
         return ResponseEntity.ok(authService.login(request));
+    }
+
+    @PostMapping("/logout")
+    public ResponseEntity<Void> logout(@RequestBody @Valid LogoutRequest request, Authentication authentication) {
+        if (authentication == null || !(authentication.getPrincipal() instanceof User user)) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+
+        authService.logout(user, request.refreshToken());
+        SecurityContextHolder.clearContext();
+        return ResponseEntity.noContent().build();
     }
 
     @PostMapping("/auth/refresh")


### PR DESCRIPTION
## Summary
- add a LogoutRequest DTO to require a refresh token when requesting logout
- add AuthService.logout to validate the authenticated user and revoke the provided refresh token
- expose POST /api/auth/logout to call the service and clear the security context after logout

## Testing
- ./mvnw test *(fails: unable to download Maven binaries in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c87bda20b0833089360b49c535f2d2