### PR TITLE
ajustes

### DIFF
--- a/src/main/java/com/nosde/memo/application/dto/ProjetoSelecionadoRequest.java
+++ b/src/main/java/com/nosde/memo/application/dto/ProjetoSelecionadoRequest.java
@@ -1,0 +1,8 @@
+package com.nosde.memo.application.dto;
+
+import lombok.Data;
+
+@Data
+public class ProjetoSelecionadoRequest {
+    private Long projetoId;
+}

--- a/src/main/java/com/nosde/memo/application/dto/UserDto.java
+++ b/src/main/java/com/nosde/memo/application/dto/UserDto.java
@@ -27,6 +27,7 @@ public class UserDto {
     private byte[] foto;
     private String role;
     private List<ProjetoDto> projetos;
+    private Long lastSelectedProjetoId;
 
     public UserDto(Long id, String email2, String nome2, String sobrenome2, SexoEnum sexo2, String cidade2,
             EstadoEnum estado, Set<DayOfWeek> diasEstudos2, DayOfWeek primeiroDiaSemana2, Set<Integer> periodoRevisao2,
@@ -48,10 +49,11 @@ public class UserDto {
         this.periodoRevisao = user.getPeriodoRevisao();
         this.classificacaoPerformance = user.getClassificacaoPerformance();
         this.foto = user.getFoto();
-        this.projetos = user.getProjetos() != null ? 
+        this.lastSelectedProjetoId = user.getLastSelectedProjetoId();
+        this.projetos = user.getProjetos() != null ?
             user.getProjetos().stream()
                 .map(projeto -> new ProjetoDto(projeto))
-                .collect(Collectors.toList()) : 
+                .collect(Collectors.toList()) :
             null;
     }
 }

--- a/src/main/java/com/nosde/memo/application/service/AuthService.java
+++ b/src/main/java/com/nosde/memo/application/service/AuthService.java
@@ -12,6 +12,7 @@ import com.nosde.memo.application.dto.RegisterRequest;
 import com.nosde.memo.application.dto.TokenResponse;
 import com.nosde.memo.application.dto.UserDto;
 import com.nosde.memo.domain.exception.UserNotFoundException;
+import com.nosde.memo.domain.model.Projeto;
 import com.nosde.memo.domain.model.RefreshToken;
 import com.nosde.memo.domain.model.User;
 import com.nosde.memo.domain.repository.UserRepository;
@@ -48,7 +49,9 @@ public class AuthService {
         user.setFoto(request.foto());
         user.setRole("ROLE_USER");
         user = userRepository.save(user);
-        projetoService.criarProjetoPadrao(user);
+        Projeto projetoPadrao = projetoService.criarProjetoPadrao(user);
+        user.setLastSelectedProjetoId(projetoPadrao.getId());
+        user = userRepository.save(user);
         return new AuthResponse(null, null, new UserDto(user));
     }
 

--- a/src/main/java/com/nosde/memo/application/service/ProjetoService.java
+++ b/src/main/java/com/nosde/memo/application/service/ProjetoService.java
@@ -53,4 +53,22 @@ public class ProjetoService {
 
         return new ProjetoDto(savedProjeto);
     }
+
+    public User selecionarProjeto(Long projetoId) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        String username = authentication.getName();
+
+        User user = userRepository.findByEmail(username)
+            .orElseThrow(() -> new ResourceNotFoundException("Usuário não encontrado: " + username));
+
+        Projeto projeto = projetoRepository.findById(projetoId)
+            .orElseThrow(() -> new ResourceNotFoundException("Projeto não encontrado: " + projetoId));
+
+        if (!projeto.getUsuario().getId().equals(user.getId())) {
+            throw new ResourceNotFoundException("Projeto não pertence ao usuário autenticado: " + projetoId);
+        }
+
+        user.setLastSelectedProjetoId(projetoId);
+        return userRepository.save(user);
+    }
 }

--- a/src/main/java/com/nosde/memo/domain/model/User.java
+++ b/src/main/java/com/nosde/memo/domain/model/User.java
@@ -78,6 +78,9 @@ public class User implements UserDetails {
     @Column(nullable = false)
     private byte[] foto;
 
+    @Column(name = "last_selected_projeto_id")
+    private Long lastSelectedProjetoId;
+
     @ElementCollection(fetch = FetchType.EAGER)
     @CollectionTable(name = "user_dias_estudos", joinColumns = @JoinColumn(name = "user_id"))
     @Column(name = "dia_estudo")

--- a/src/main/java/com/nosde/memo/interfaces/controller/ProjetoController.java
+++ b/src/main/java/com/nosde/memo/interfaces/controller/ProjetoController.java
@@ -8,6 +8,8 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.nosde.memo.application.dto.ProjetoDto;
 import com.nosde.memo.application.dto.ProjetoRequest;
+import com.nosde.memo.application.dto.ProjetoSelecionadoRequest;
+import com.nosde.memo.application.dto.UserDto;
 import com.nosde.memo.application.service.ProjetoService;
 
 import lombok.RequiredArgsConstructor;
@@ -23,5 +25,10 @@ public class ProjetoController {
     public ResponseEntity<ProjetoDto> createProjeto(@RequestBody ProjetoRequest projeto) {
         return ResponseEntity.ok(projetoService.criarProjeto(projeto));
     }
-    
+
+    @PostMapping("/selecionar")
+    public ResponseEntity<UserDto> selecionarProjeto(@RequestBody ProjetoSelecionadoRequest request) {
+        return ResponseEntity.ok(new UserDto(projetoService.selecionarProjeto(request.getProjetoId())));
+    }
+
 }


### PR DESCRIPTION
## Summary
- add a column to the User entity and DTO to expose the last selected project
- persist the last selected project during registration and when switching projects through the service
- expose an endpoint to select a project and return the updated User DTO

## Testing
- mvn test *(fails: Non-resolvable parent POM for com.nosde:memo due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68cf546a68f08330801a25ad06e460a3