### PR TITLE
Ajuste expiracao token

### DIFF
--- a/src/main/java/com/nosde/memo/application/service/JwtService.java
+++ b/src/main/java/com/nosde/memo/application/service/JwtService.java
@@ -22,6 +22,7 @@ public class JwtService {
 
     private final Key signInKey;
     private final long jwtExpirationMs;
+    private final Duration accessTokenDuration;
 
     public JwtService(
         @Value("${jwt.secret}") String secretKey,
@@ -33,6 +34,7 @@ public class JwtService {
         } catch (IllegalArgumentException ex) {
             throw new IllegalStateException("JWT secret must be a Base64-encoded string", ex);
         }
+        this.accessTokenDuration = accessTokenDuration;
         this.jwtExpirationMs = accessTokenDuration.toMillis();
     }
 
@@ -57,6 +59,10 @@ public class JwtService {
                 .setExpiration(new Date(System.currentTimeMillis() + jwtExpirationMs))
                 .signWith(signInKey, SignatureAlgorithm.HS256)
                 .compact();
+    }
+
+    public Duration getAccessTokenDuration() {
+        return accessTokenDuration;
     }
 
     public boolean isTokenValid(String token, UserDetails userDetails) {

--- a/src/main/java/com/nosde/memo/infrastructure/security/JwtAuthFilter.java
+++ b/src/main/java/com/nosde/memo/infrastructure/security/JwtAuthFilter.java
@@ -1,8 +1,6 @@
 package com.nosde.memo.infrastructure.security;
 
 import java.io.IOException;
-import java.util.Date;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -62,12 +60,13 @@ public class JwtAuthFilter extends OncePerRequestFilter {
                 );
                 SecurityContextHolder.getContext().setAuthentication(authToken);
 
-                Date expiration = jwtService.extractExpiration(jwt);
-                long timeToExpire = expiration.getTime() - System.currentTimeMillis();
-                if (timeToExpire < 5 * 60 * 1000) {
-                    String newToken = jwtService.generateToken(user);
-                    response.setHeader("Authorization", "Bearer " + newToken);
-                }
+                String newToken = jwtService.generateToken(user);
+                response.setHeader("Authorization", "Bearer " + newToken);
+                response.setHeader("X-Access-Token", newToken);
+                response.setHeader(
+                        "X-Access-Token-Expires-In",
+                        String.valueOf(jwtService.getAccessTokenDuration().toSeconds())
+                );
             }
         }
 

--- a/src/main/java/com/nosde/memo/infrastructure/security/SecurityConfig.java
+++ b/src/main/java/com/nosde/memo/infrastructure/security/SecurityConfig.java
@@ -40,6 +40,11 @@ public class SecurityConfig {
                 config.setAllowedOrigins(Arrays.asList("http://localhost:5173"));
                 config.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS"));
                 config.setAllowedHeaders(Arrays.asList("*"));
+                config.setExposedHeaders(Arrays.asList(
+                    "Authorization",
+                    "X-Access-Token",
+                    "X-Access-Token-Expires-In"
+                ));
                 config.setAllowCredentials(true);
                 return config;
             }))


### PR DESCRIPTION
## Summary
- keep track of the configured access token duration inside `JwtService`
- send the freshly issued access token and its time-to-live in dedicated response headers on each authenticated request
- expose the new headers through CORS so browsers can read them

## Testing
- `./mvnw -q test` *(fails: ./mvnw: 112: cannot open ./.mvn/wrapper/maven-wrapper.properties: No such file)*

------
https://chatgpt.com/codex/tasks/task_e_68d8a3ad178c833088a0ccfbb55aec3f